### PR TITLE
Add WordPress Block Editor to adoption list

### DIFF
--- a/adoption.rst
+++ b/adoption.rst
@@ -41,7 +41,6 @@ bodies of documentation. In some cases the adoption remains partial or is still 
 * `WebAccess/DMP <https://docs.wadmp.com>`_
 * `Wechaty <https://wechaty.js.org/docs/>`_
 * `WordPress Block Editor <https://developer.wordpress.org/block-editor/>`_
-
 * Zalando (internal)
 
 


### PR DESCRIPTION
We try to shape our documentation at: https://developer.wordpress.org/block-editor/ to this model.
It has given us a good way to think about how to organize.