### PR TITLE
fixes wrong Link target

### DIFF
--- a/explanation.rst
+++ b/explanation.rst
@@ -66,7 +66,7 @@ Don't instruct, or provide technical reference
 Example from Divio's documentation
 ----------------------------------
 
-Have a look at `our explanation section <https://docs.divio.com/en/latest/reference/divio-cli>`_ (titled "Background" -
+Have a look at `our explanation section <https://docs.divio.com/en/latest/background/>`_ (titled "Background" -
 the name is not important as long as the purpose is clear).
 
 .. image:: /images/divio-explanation-example.png


### PR DESCRIPTION
the replaced link was part of the previous chapter about references.
the new link leads to the actual backlog-information of the divio documentation