### PR TITLE
Fixed wrong link

### DIFF
--- a/explanation.rst
+++ b/explanation.rst
@@ -66,8 +66,7 @@ Don't instruct, or provide technical reference
 Example from Divio's documentation
 ----------------------------------
 
-Have a look at `our explanation section <https://docs.divio.com/en/latest/reference/divio-cli>`_ (titled "Background" -
-the name is not important as long as the purpose is clear).
+Have a look at `our explanation section <https://docs.divio.com/en/latest/background/`_ (titled "Background" - the name is not important as long as the purpose is clear).
 
 .. image:: /images/divio-explanation-example.png
    :alt: 'Django explanation example'

--- a/explanation.rst
+++ b/explanation.rst
@@ -66,7 +66,8 @@ Don't instruct, or provide technical reference
 Example from Divio's documentation
 ----------------------------------
 
-Have a look at `our explanation section <https://docs.divio.com/en/latest/background/`_ (titled "Background" - the name is not important as long as the purpose is clear).
+Have a look at `our explanation section <https://docs.divio.com/en/latest/background/`_ (titled "Background" - the name 
+is not important as long as the purpose is clear).
 
 .. image:: /images/divio-explanation-example.png
    :alt: 'Django explanation example'


### PR DESCRIPTION
https://app.intercom.com/a/inbox/wcfe7111/inbox/team/757519/conversation/12160300227333?view=List
In https://documentation.divio.com/explanation/, the link leads to the wrong URL, which is https://docs.divio.com/en/latest/reference/divio-cli/. The correct URL is supposed to be https://docs.divio.com/en/latest/background/.